### PR TITLE
Added link of System Design Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,3 +360,5 @@ AWS CloudFront CDN with S3: https://aws.amazon.com/blogs/networking-and-content-
 Designing Data Intensive Applications: https://amzn.to/3SyNAOy
 
 InterviewReady Videos: [https://interviewready.io](https://interviewready.io?_aff=HELLOWORLD&source=github)
+
+System Design Roadmap: [https://roadmap.sh/system-design](https://roadmap.sh/system-design)


### PR DESCRIPTION
Hi @coding-parrot,

I came across your repository [system-design-resources](https://github.com/InterviewReady/system-design-resources) and found it to be a valuable resource for System Design enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["System Design Roadmap"](https://roadmap.sh/system-design). I took the initiative to submit a ["Pull Request"](https://github.com/InterviewReady/system-design-resources/pull/17) adding it in "System Design Resources" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz